### PR TITLE
Fix chrome touch

### DIFF
--- a/src/components/PlaybackControls.js
+++ b/src/components/PlaybackControls.js
@@ -150,7 +150,7 @@ function VolumeSlider({ player }) {
 function PlaybackControls({ player }) {
   return h(
     "div",
-    { className: "d-flex bg-dark text-light no-select" },
+    { className: "d-flex bg-dark text-light no-select no-touch-action" },
     // Play button
     h(
       "button",

--- a/src/components/PlaybackControls.js
+++ b/src/components/PlaybackControls.js
@@ -61,6 +61,11 @@ function ProgressBar({ player }) {
           if (wasPlaying) player.play();
         }
       },
+      onPointerCancel() {
+        if (dragging) {
+          setDragging(false);
+        }
+      },
       onPointerMove(e) {
         if (dragging) {
           updatePosition(e);
@@ -113,6 +118,11 @@ function VolumeSlider({ player }) {
         if (dragging) {
           setDragging(false);
           updatePosition(e);
+        }
+      },
+      onPointerCancel() {
+        if (dragging) {
+          setDragging(false);
         }
       },
       onPointerMove(e) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -168,3 +168,6 @@ a {
 .no-select {
   user-select: none;
 }
+.no-touch-action {
+  touch-action: none;
+}


### PR DESCRIPTION
Fixes #6.

Adds CSS `touch-action: none;` to the PlaybackControls component to disable browser actions like panning, and allow the slider to operate as expected.